### PR TITLE
Add an example of caching plugin dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout source code
 
+    - uses: actions/cache@v2
+      name: Cache plugin dir
+      with:
+        path: ~/.tflint.d/plugins
+        key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
     - uses: terraform-linters/setup-tflint@v1
       name: Setup TFLint
       with:


### PR DESCRIPTION
Caching plugin dir is useful for avoiding the GitHub API rate limits, so it's probably a good idea to give it as a usage.
See also https://github.com/terraform-linters/tflint/issues/1142