### PR TITLE
Change 'matchersPath' to be relative to github_workspace, supporting monorepos.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Setup TFLint'
+name: 'Setup TFLint test'
 description: 'Sets up tflint CLI in your GitHub Actions workflow'
-author: 'jgeurts'
+author: 'bnayah'
 inputs:
   tflint_version:
     description: TFLint version to install

--- a/src/setup-tflint.js
+++ b/src/setup-tflint.js
@@ -1,5 +1,6 @@
 const os = require('os');
 const path = require('path');
+const process = require('process');
 
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
@@ -85,7 +86,7 @@ async function run() {
 
     core.addPath(pathToCLI);
 
-    const matchersPath = path.join(__dirname, '..', '.github');
+    const matchersPath = path.join(String(process.env.GITHUB_WORKSPACE), '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'matchers.json')}`);
 
     return version;


### PR DESCRIPTION
Current 'matchersPath' is hardcoded to expect the .github folder relative to the __dirname.

This amends that to be relative to the GITHUB_WORKSPACE.

This is relevant in cases where a terraform monorepo pattern is used to manage multiple accounts.

matchers.json is kept/managed in the .github/ dir, however the "linting" directory will be different.

Closes #19 