### PR TITLE
Set default GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Default: `"latest"`
 
 ### `github_token`
 
-If set, `github_token` will be used for Octokit authentication. Authenticating will increase the [API rate limit](https://developer.github.com/v3/#rate-limiting) when querying the tflint repository to get the latest release version.
+Used to authenticate requests to the GitHub API to obtain release data from the TFLint repository. Authenticating will increase the [API rate limit](https://developer.github.com/v3/#rate-limiting). Any valid token is supported. No permissions are required.
+
+Default: `${{ github.token }}
 
 ## Outputs
 
@@ -75,12 +77,12 @@ or specify it explicitly as
     tflint_version: latest
 ```
 
-### Using `GITHUB_TOKEN`
+### Using Custom GitHub Token
 
 ```yaml
 - uses: terraform-linters/setup-tflint@v2
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
+    github_token: ${{ secrets.MY_CUSTOM_GITHUB_TOKEN }}
 ```
 
 ### Loading Shared Configuration

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Default: `"latest"`
 
 Used to authenticate requests to the GitHub API to obtain release data from the TFLint repository. Authenticating will increase the [API rate limit](https://developer.github.com/v3/#rate-limiting). Any valid token is supported. No permissions are required.
 
-Default: `${{ github.token }}
+Default: `${{ github.token }}`
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
   github_token:
     description: GitHub token - used when getting the latest version of tflint
     required: false
+    default: ${{ github.token }}
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
`secrets.GITHUB_TOKEN` can't be used as a default input because `secrets` context is not available in that part of the manifest, but `github` context is available, so it's possible to set a default token.