### PR TITLE
docs: include `GITHUB_TOKEN` in init example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ jobs:
 
     - name: Init TFLint
       run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Run TFLint
       run: tflint -f compact


### PR DESCRIPTION
Includes `GITHUB_TOKEN` in the init example. On private hosts, including self-hosted runners, this is optional. On shared Actions runners, this is practically required to avoid random rate limiting.

See also https://github.com/terraform-linters/tflint/pull/1708
Closes #143