### PR TITLE
disable `github_token` in GHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@ Default: `"latest"`
 
 Used to authenticate requests to the GitHub API to obtain release data from the TFLint repository. Authenticating will increase the [API rate limit](https://developer.github.com/v3/#rate-limiting). Any valid token is supported. No permissions are required.
 
-Default: `${{ github.token }}`
+Default: `${{ github.server_url == 'https://github.com' && github.token || '' }}`
 
-To disable authentication, set this value to an empty string (`""`). GitHub Enterprise Server tokens will not be accepted by `github.com`. GHES users must either:
-
-* Disable authentication
-* Provide an API token issued from `github.com`
-  * [Apps](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) are the preferred way to authenticate on behalf of an organization
+GitHub Enterprise Server will make requests to github.com anonymously by default. To authenticate these requests, you must issue a token from github.com and pass it explicitly.
 
 ### `tflint_wrapper`
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   github_token:
     description: GitHub token - used when getting the latest version of tflint
     required: false
-    default: ${{ github.token }}
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   tflint_wrapper:
     description: Installs a wrapper script to wrap subsequent calls to `tflint` and expose `stdout`, `stderr`, and `exitcode` outputs
     default: 'false'


### PR DESCRIPTION
If GitHub Actions is running on a server other than `github.com`, this PR makes the `github_token` empty by default. This works by default for GHES users, instead of requiring them to override the default token which is mismatched.

I spotted this technique in https://github.com/actions/setup-node.

Replaces #186.