### PR TITLE
Add support for multiple SHA256 hash values for TFLint download verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ If version is `"latest"`, the action will get the latest version number using [O
 
 Default: `"latest"`
 
+### `expected_sha256`
+
+A comma-separated list of expected SHA256 hashes of the downloaded TFLint binary. If provided, the action will verify the binary’s integrity and proceed only if one of the hashes matches the computed hash. 
+
+This feature can help validate downloads from different sources or mirrors.
+
 ### `github_token`
 
 Used to authenticate requests to the GitHub API to obtain release data from the TFLint repository. Authenticating will increase the [API rate limit](https://developer.github.com/v3/#rate-limiting). Any valid token is supported. No permissions are required.
@@ -32,7 +38,7 @@ Default: `"false"`
 The following outputs are available when the `tflint_wrapper` input is enabled:
 
 - `stdout` - The output (stdout) produced by the tflint command.
-- `stderr` - The error output (stdout) produced by the tflint command.
+- `stderr` - The error output (stderr) produced by the tflint command.
 - `exitcode` - The exit code produced by the tflint command.
 
 ## Usage
@@ -66,6 +72,7 @@ jobs:
       name: Setup TFLint
       with:
         tflint_version: v0.52.0
+        expected_sha256: "40f7ee2dbeb8e7cbd5ab7b10912f60eb14aa4fbff62603eeb67fdb5f7cbb794a,bf758ff29b607b3fbc4a3630ea3b39df4afafe3cdb80c6d71fe528feeac2c58e,fed6ff15ee10db34a23044ac0d4da8fdc1f2f3663b32ec85d388374dd95670aa"
 
     - name: Show version
       run: tflint --version

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: 'false'
     required: false
   expected_sha256:
-    description: The expected SHA256 hash of the downloaded TFLint binary. If provided, the action will verify the binary's integrity and only proceed if the hash matches.
+    description: Comma-separated list of expected SHA256 hashes of the downloaded TFLint binary. If provided, the action will verify the binary’s integrity and only proceed if one of the hashes matches.
     required: false
 outputs:
   stdout:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: Installs a wrapper script to wrap subsequent calls to `tflint` and expose `stdout`, `stderr`, and `exitcode` outputs
     default: 'false'
     required: false
+  expected_sha256:
+    description: The expected SHA256 hash of the downloaded TFLint binary. If provided, the action will verify the binary's integrity and only proceed if the hash matches.
+    required: false
 outputs:
   stdout:
     description: The output (stdout) produced by the tflint command. Only available if `tflint_wrapper` is set to `true`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -14541,15 +14541,15 @@ async function computeSHA256(filePath) {
   });
 }
 
-async function downloadCLI(url, expectedHash) {
+async function downloadCLI(url, expectedHashes) {
   core.debug(`Downloading tflint CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  if (expectedHash) {
+  if (expectedHashes) {
     core.debug('Verifying SHA256 hash of downloaded file');
     const computedHash = await computeSHA256(pathToCLIZip);
-    if (computedHash !== expectedHash) {
-      throw new Error(`SHA256 hash mismatch: expected ${expectedHash}, but got ${computedHash}`);
+    if (!expectedHashes.includes(computedHash)) {
+      throw new Error(`SHA256 hash mismatch: expected one of ${expectedHashes.join(', ')}, but got ${computedHash}`);
     }
     core.debug('SHA256 hash verified successfully');
   }
@@ -14598,7 +14598,7 @@ async function installWrapper(pathToCLI) {
 async function run() {
   try {
     const inputVersion = core.getInput('tflint_version');
-    const expectedHash = core.getInput('expected_sha256');
+    const expectedHashes = core.getInput('expected_sha256').split(',').map(hash => hash.trim());
     const wrapper = core.getInput('tflint_wrapper') === 'true';
     const version = await getTFLintVersion(inputVersion);
     const platform = mapOS(os.platform());
@@ -14607,7 +14607,7 @@ async function run() {
     core.debug(`Getting download URL for tflint version ${version}: ${platform} ${arch}`);
     const url = `https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${platform}_${arch}.zip`;
 
-    const pathToCLI = await downloadCLI(url, expectedHash);
+    const pathToCLI = await downloadCLI(url, expectedHashes);
 
     if (wrapper) {
       await installWrapper(pathToCLI);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-tflint-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-tflint-action",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-tflint-action",
-  "version": "2.0.0",
-  "description": "Install and setup TFLint executable Action",
+  "version": "2.1.0",
+  "description": "Install and setup TFLint executable Action with SHA256 verification",
   "main": "index.js",
   "scripts": {
     "lint": "eslint --fix . src test",
@@ -24,7 +24,9 @@
     "GitHub",
     "Actions",
     "TFLint",
-    "Terraform"
+    "Terraform",
+    "SHA256",
+    "Verification"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This PR enhances the TFLint setup action by allowing multiple expected SHA256 hash values for verifying the downloaded binary. With this update:

- **Multiple Hash Verification**: The `expected_sha256` input now accepts a comma-separated list of SHA256 hashes. This enables the action to validate the integrity of the TFLint binary against multiple valid hashes, adding flexibility when downloading from different sources or mirrors.
- **Documentation Updates**:
  - Updated `action.yml` to reflect that `expected_sha256` supports multiple hashes.
  - Revised `README.md` to include instructions for providing multiple hashes, with an example in the `Usage` section.
- **Usage Example**: In the README, users can now see how to pass multiple expected hashes to the action.

This improvement ensures that the setup action can handle variations in binary hash values across sources while maintaining integrity checks. Please review the changes and confirm if any additional updates are needed.

I think this should resolve https://github.com/terraform-linters/setup-tflint/issues/16.