### PR TITLE
fix: treat tflint exit code 2 as failure

### DIFF
--- a/dist/index1.js
+++ b/dist/index1.js
@@ -3596,13 +3596,12 @@ async function checkTflint() {
   core.setOutput('stderr', stderr.contents);
   core.setOutput('exitcode', exitCode.toString(10));
 
-  if (exitCode === 0 || exitCode === 2) {
-    // A exitCode of 0 is considered a success
-    // An exitCode of 2 denotes no errors occurred, but issues found
-    return;
+  if (exitCode !== 0) {
+    // Any non-zero exit code is considered a failure
+    // Exit code 1: Errors in tflint execution
+    // Exit code 2: Issues found above --minimum-failure-severity threshold
+    // Exit code 3+: Other errors
+    core.setFailed(`TFLint exited with code ${exitCode}.`);
   }
-
-  // A non-zero exitCode is considered an error
-  core.setFailed(`TFLint exited with code ${exitCode}.`);
 })();
 

--- a/wrapper/tflint.js
+++ b/wrapper/tflint.js
@@ -41,12 +41,11 @@ async function checkTflint() {
   core.setOutput('stderr', stderr.contents);
   core.setOutput('exitcode', exitCode.toString(10));
 
-  if (exitCode === 0 || exitCode === 2) {
-    // A exitCode of 0 is considered a success
-    // An exitCode of 2 denotes no errors occurred, but issues found
-    return;
+  if (exitCode !== 0) {
+    // Any non-zero exit code is considered a failure
+    // Exit code 1: Errors in tflint execution
+    // Exit code 2: Issues found above --minimum-failure-severity threshold
+    // Exit code 3+: Other errors
+    core.setFailed(`TFLint exited with code ${exitCode}.`);
   }
-
-  // A non-zero exitCode is considered an error
-  core.setFailed(`TFLint exited with code ${exitCode}.`);
 })();


### PR DESCRIPTION
Fixes the wrapper to properly handle tflint exit codes. The wrapper was incorrectly treating exit code 2 as success.

## Issue

tflint exits with code 2 when it finds issues that should cause failure (based on `--minimum-failure-severity` if set, or any issues if not set). The wrapper was treating this as success, which is incorrect.

## Changes

- Treat any non-zero exit code as failure (exit code 2 means "issues found that should fail")
- Add comments documenting exit code meanings

## Breaking Change

⚠️ The wrapper now correctly fails when tflint finds issues. To ignore warnings, use `--minimum-failure-severity=error`.

Fixes #323