### PR TITLE
feat: show tflint version and set output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,10 +107,13 @@ jobs:
       if: matrix.tflint_version == 'latest'
       run: tflint -v
     - name: Verify version output
-      if: matrix.tflint_version != 'latest'
       run: |
-        version='${{ matrix.tflint_version }}'
-        expected=${version:1}
+        if [[ "${{ matrix.tflint_version }}" == "latest" ]]; then
+          expected=$(gh api repos/terraform-linters/tflint/releases/latest --jq '.tag_name' | sed 's/^v//')
+        else
+          version='${{ matrix.tflint_version }}'
+          expected=${version:1}
+        fi
         if [[ "${{ steps.setup-tflint.outputs.tflint-version }}" != "$expected" ]]; then
           echo "Expected version output '$expected', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
           exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,8 @@ jobs:
           echo "Expected version output '$expected', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
           exit 1
         fi
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   integration-checksum:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,3 +184,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify plugin installed
         run: test -d ~/.tflint.d/plugins
+
+  integration-version-output:
+    name: 'Integration test: version output'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Use Action
+        id: setup-tflint
+        uses: ./
+        with:
+          tflint_version: 'v0.53.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify version output
+        run: |
+          if [[ "${{ steps.setup-tflint.outputs.tflint-version }}" != "0.53.0" ]]; then
+            echo "Expected version output '0.53.0', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Use Action
+      id: setup-tflint
       uses: ./
       with:
         tflint_version: ${{ matrix.tflint_version }}
@@ -105,6 +106,15 @@ jobs:
     - name: Validate
       if: matrix.tflint_version == 'latest'
       run: tflint -v
+    - name: Verify version output
+      if: matrix.tflint_version != 'latest'
+      run: |
+        version='${{ matrix.tflint_version }}'
+        expected=${version:1}
+        if [[ "${{ steps.setup-tflint.outputs.tflint-version }}" != "$expected" ]]; then
+          echo "Expected version output '$expected', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
+          exit 1
+        fi
 
   integration-checksum:
     runs-on: ubuntu-latest
@@ -184,22 +194,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify plugin installed
         run: test -d ~/.tflint.d/plugins
-
-  integration-version-output:
-    name: 'Integration test: version output'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Use Action
-        id: setup-tflint
-        uses: ./
-        with:
-          tflint_version: 'v0.53.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Verify version output
-        run: |
-          if [[ "${{ steps.setup-tflint.outputs.tflint-version }}" != "0.53.0" ]]; then
-            echo "Expected version output '0.53.0', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
-            exit 1
-          fi

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
     default: '~/.tflint.d/plugins'
     required: false
 outputs:
+  tflint-version:
+    description: The installed version of TFLint
   stdout:
     description: The output (stdout) produced by the tflint command. Only available if `tflint_wrapper` is set to `true`.
   stderr:


### PR DESCRIPTION
Adds high-level logging for installation steps and sets the installed TFLint version as an output.

## Changes

- Adds `core.info` logs for download and extraction steps (similar to `actions/setup-node`)
- Calls `tflint --version` after installation to extract actual version
- Sets `tflint-version` output with the extracted version
- Version extraction handles errors gracefully with warnings (doesn't fail the action)
- Updates `integration-versions` job to verify version output is set correctly

## Testing

- Updated `integration-versions` job verifies output for both exact versions and `latest`

Closes #350