### PR TITLE
feat: add cache-hit output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
 outputs:
   tflint-version:
     description: The installed version of TFLint
+  cache-hit:
+    description: A boolean value to indicate a cache entry was found
   stdout:
     description: The output (stdout) produced by the tflint command. Only available if `tflint_wrapper` is set to `true`.
   stderr:

--- a/dist/index.js
+++ b/dist/index.js
@@ -88934,6 +88934,8 @@ async function restoreCache() {
   const restoreKeys = [keyPrefix];
   const matchedKey = await cache.restoreCache([pluginDir], primaryKey, restoreKeys);
 
+  core.setOutput('cache-hit', Boolean(matchedKey));
+
   if (!matchedKey) {
     core.info('TFLint plugin cache not found');
     return;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -84066,6 +84066,8 @@ async function restoreCache() {
   const restoreKeys = [keyPrefix];
   const matchedKey = await cache.restoreCache([pluginDir], primaryKey, restoreKeys);
 
+  core.setOutput('cache-hit', Boolean(matchedKey));
+
   if (!matchedKey) {
     core.info('TFLint plugin cache not found');
     return;

--- a/src/cache-restore.js
+++ b/src/cache-restore.js
@@ -50,6 +50,8 @@ async function restoreCache() {
   const restoreKeys = [keyPrefix];
   const matchedKey = await cache.restoreCache([pluginDir], primaryKey, restoreKeys);
 
+  core.setOutput('cache-hit', Boolean(matchedKey));
+
   if (!matchedKey) {
     core.info('TFLint plugin cache not found');
     return;


### PR DESCRIPTION
Adds `cache-hit` output to indicate whether the plugin cache was restored.

## Changes

- Adds `cache-hit` output to `action.yml`
- Sets output in `cache-restore.js` after attempting cache restoration

Closes #352