### PR TITLE
Extract release-target and installer modules with tests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44845,8 +44845,6 @@ function getIDToken(aud) {
  */
 
 //# sourceMappingURL=core.js.map
-;// CONCATENATED MODULE: external "stream/promises"
-const promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("stream/promises");
 // EXTERNAL MODULE: ./node_modules/@actions/tool-cache/node_modules/semver/index.js
 var node_modules_semver = __nccwpck_require__(885);
 ;// CONCATENATED MODULE: ./node_modules/@actions/tool-cache/lib/manifest.js
@@ -99889,7 +99887,9 @@ async function cache_restore_restoreCache() {
 /* harmony default export */ const cache_restore = (cache_restore_restoreCache);
 
 
-;// CONCATENATED MODULE: ./src/setup-tflint.js
+;// CONCATENATED MODULE: external "stream/promises"
+const promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("stream/promises");
+;// CONCATENATED MODULE: ./src/installer.js
 
 
 
@@ -99897,13 +99897,71 @@ async function cache_restore_restoreCache() {
 
 
 
+/**
+ * Compute the SHA256 hash of a file
+ * @param {string} filePath - Path to the file to hash
+ * @returns {Promise<string>} - Hex-encoded SHA256 digest
+ */
+async function fileSHA256(filePath) {
+  const hash = external_crypto_namespaceObject.createHash('sha256');
+  const fileStream = external_fs_namespaceObject.createReadStream(filePath); // eslint-disable-line security/detect-non-literal-fs-filename
 
+  await (0,promises_namespaceObject.pipeline)(fileStream, hash);
+  return hash.digest('hex');
+}
 
+/**
+ * Verify a checksum against the list of allowed checksums
+ * @param {string} checksum - The computed checksum
+ * @param {string[]} checksums - Allowed checksums; empty list skips verification
+ * @returns {void}
+ */
+function verifyChecksum(checksum, checksums) {
+  if (checksums.length === 0) {
+    return;
+  }
 
+  if (!checksums.includes(checksum)) {
+    throw new Error(
+      `Mismatched checksum: expected one of ${checksums.join(', ')}, but got ${checksum}`,
+    );
+  }
+}
 
+/**
+ * Download, verify, and extract the tflint CLI
+ * @param {string} url - Release asset download URL
+ * @param {string[]} checksums - Allowed checksums; empty list skips verification
+ * @param {string} version - Version being installed (for logging)
+ * @returns {Promise<string>} - Path to the extracted CLI directory
+ */
+async function downloadCLI(url, checksums, version) {
+  info(`Attempting to download ${version}...`);
+  info(`Acquiring ${version} from ${url}`);
+  const pathToCLIZip = await downloadTool(url);
 
+  if (checksums.length > 0) {
+    core_debug('Verifying checksum of downloaded file');
 
+    const checksum = await fileSHA256(pathToCLIZip);
 
+    verifyChecksum(checksum, checksums);
+
+    core_debug('SHA256 hash verified successfully');
+  }
+
+  info('Extracting...');
+  const pathToCLI = await extractZip(pathToCLIZip);
+  core_debug(`tflint CLI path is ${pathToCLI}.`);
+
+  if (!pathToCLIZip || !pathToCLI) {
+    throw new Error(`Unable to download tflint from ${url}`);
+  }
+
+  return pathToCLI;
+}
+
+;// CONCATENATED MODULE: ./src/release-target.js
 /**
  * Normalize version for tool-cache compatibility
  * @param {string} version - Version string (e.g., "v0.50.0" or "0.50.0")
@@ -99938,62 +99996,69 @@ function mapOS(osPlatform) {
   return mappings[osPlatform] || osPlatform;
 }
 
+/**
+ * Build the release asset download URL for a tflint version
+ * @param {string} version - Release version (with any leading "v")
+ * @param {string} platform - GitHub OS name
+ * @param {string} arch - GitHub architecture name
+ * @returns {string}
+ */
+function buildDownloadUrl(version, platform, arch) {
+  return `https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${platform}_${arch}.zip`;
+}
+
+/**
+ * Resolve the release version and construct the download target
+ * @param {object} options
+ * @param {string} options.inputVersion - Requested version input ("latest", empty, or explicit)
+ * @param {string} options.platform - GitHub OS name
+ * @param {string} options.arch - GitHub architecture name
+ * @param {Function} options.fetchLatestReleaseName - Injected async fetcher returning the latest release name
+ * @returns {Promise<{version: string, downloadUrl: string}>}
+ */
+async function resolveReleaseTarget({
+  inputVersion,
+  platform,
+  arch,
+  fetchLatestReleaseName,
+}) {
+  const version =
+    !inputVersion || inputVersion === 'latest' ? await fetchLatestReleaseName() : inputVersion;
+
+  return {
+    version,
+    downloadUrl: buildDownloadUrl(version, platform, arch),
+  };
+}
+
+;// CONCATENATED MODULE: ./src/setup-tflint.js
+
+
+
+
+
+
+
+
+
+
+
+
+
 function getOctokit() {
   return new dist_src_Octokit({
     auth: getInput('github_token'),
   });
 }
 
-async function getTFLintVersion(inputVersion) {
-  if (!inputVersion || inputVersion === 'latest') {
-    const octokit = getOctokit();
-    const response = await octokit.repos.getLatestRelease({
-      owner: 'terraform-linters',
-      repo: 'tflint',
-    });
-    core_debug(`... version resolved to [${response.data.name}]`);
-    return response.data.name;
-  }
-
-  return inputVersion;
-}
-
-async function fileSHA256(filePath) {
-  const hash = external_crypto_namespaceObject.createHash('sha256');
-  const fileStream = external_fs_namespaceObject.createReadStream(filePath); // eslint-disable-line security/detect-non-literal-fs-filename
-
-  await (0,promises_namespaceObject.pipeline)(fileStream, hash);
-  return hash.digest('hex');
-}
-
-async function downloadCLI(url, checksums, version) {
-  info(`Attempting to download ${version}...`);
-  info(`Acquiring ${version} from ${url}`);
-  const pathToCLIZip = await downloadTool(url);
-
-  if (checksums.length > 0) {
-    core_debug('Verifying checksum of downloaded file');
-
-    const checksum = await fileSHA256(pathToCLIZip);
-
-    if (!checksums.includes(checksum)) {
-      throw new Error(
-        `Mismatched checksum: expected one of ${checksums.join(', ')}, but got ${checksum}`,
-      );
-    }
-
-    core_debug('SHA256 hash verified successfully');
-  }
-
-  info('Extracting...');
-  const pathToCLI = await extractZip(pathToCLIZip);
-  core_debug(`tflint CLI path is ${pathToCLI}.`);
-
-  if (!pathToCLIZip || !pathToCLI) {
-    throw new Error(`Unable to download tflint from ${url}`);
-  }
-
-  return pathToCLI;
+async function fetchLatestReleaseName() {
+  const octokit = getOctokit();
+  const response = await octokit.repos.getLatestRelease({
+    owner: 'terraform-linters',
+    repo: 'tflint',
+  });
+  core_debug(`... version resolved to [${response.data.name}]`);
+  return response.data.name;
 }
 
 async function getInstalledVersion() {
@@ -100046,9 +100111,14 @@ async function run() {
     const inputVersion = getInput('tflint_version');
     const checksums = getMultilineInput('checksums');
     const wrapper = getInput('tflint_wrapper') === 'true';
-    const version = await getTFLintVersion(inputVersion);
     const platform = mapOS(external_os_.platform());
     const arch = mapArch(external_os_.arch());
+    const { version, downloadUrl } = await resolveReleaseTarget({
+      inputVersion,
+      platform,
+      arch,
+      fetchLatestReleaseName,
+    });
     const normalizedVersion = normalizeVersion(version);
 
     // Check if tool is already cached
@@ -100057,9 +100127,8 @@ async function run() {
       info(`Found TFLint ${version} in cache @ ${pathToCLI}`);
     } else {
       core_debug(`Getting download URL for tflint version ${version}: ${platform} ${arch}`);
-      const url = `https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${platform}_${arch}.zip`;
 
-      pathToCLI = await downloadCLI(url, checksums, version);
+      pathToCLI = await downloadCLI(downloadUrl, checksums, version);
 
       info('Adding to the tool cache...');
       pathToCLI = await cacheDir(pathToCLI, 'tflint', normalizedVersion, arch);

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,0 +1,70 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import { pipeline } from 'stream/promises';
+
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+
+/**
+ * Compute the SHA256 hash of a file
+ * @param {string} filePath - Path to the file to hash
+ * @returns {Promise<string>} - Hex-encoded SHA256 digest
+ */
+export async function fileSHA256(filePath) {
+  const hash = crypto.createHash('sha256');
+  const fileStream = fs.createReadStream(filePath); // eslint-disable-line security/detect-non-literal-fs-filename
+
+  await pipeline(fileStream, hash);
+  return hash.digest('hex');
+}
+
+/**
+ * Verify a checksum against the list of allowed checksums
+ * @param {string} checksum - The computed checksum
+ * @param {string[]} checksums - Allowed checksums; empty list skips verification
+ * @returns {void}
+ */
+export function verifyChecksum(checksum, checksums) {
+  if (checksums.length === 0) {
+    return;
+  }
+
+  if (!checksums.includes(checksum)) {
+    throw new Error(
+      `Mismatched checksum: expected one of ${checksums.join(', ')}, but got ${checksum}`,
+    );
+  }
+}
+
+/**
+ * Download, verify, and extract the tflint CLI
+ * @param {string} url - Release asset download URL
+ * @param {string[]} checksums - Allowed checksums; empty list skips verification
+ * @param {string} version - Version being installed (for logging)
+ * @returns {Promise<string>} - Path to the extracted CLI directory
+ */
+export async function downloadCLI(url, checksums, version) {
+  core.info(`Attempting to download ${version}...`);
+  core.info(`Acquiring ${version} from ${url}`);
+  const pathToCLIZip = await tc.downloadTool(url);
+
+  if (checksums.length > 0) {
+    core.debug('Verifying checksum of downloaded file');
+
+    const checksum = await fileSHA256(pathToCLIZip);
+
+    verifyChecksum(checksum, checksums);
+
+    core.debug('SHA256 hash verified successfully');
+  }
+
+  core.info('Extracting...');
+  const pathToCLI = await tc.extractZip(pathToCLIZip);
+  core.debug(`tflint CLI path is ${pathToCLI}.`);
+
+  if (!pathToCLIZip || !pathToCLI) {
+    throw new Error(`Unable to download tflint from ${url}`);
+  }
+
+  return pathToCLI;
+}

--- a/src/installer.test.js
+++ b/src/installer.test.js
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('@actions/core', () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.unstable_mockModule('@actions/tool-cache', () => ({
+  downloadTool: jest.fn(),
+  extractZip: jest.fn(),
+}));
+
+const tc = await import('@actions/tool-cache');
+const { downloadCLI, verifyChecksum } = await import('./installer.js');
+
+describe('verifyChecksum', () => {
+  it('does not throw when the checksum list is empty', () => {
+    expect(() => verifyChecksum('abc123', [])).not.toThrow();
+  });
+
+  it('does not throw when the checksum matches', () => {
+    expect(() => verifyChecksum('abc123', ['abc123', 'def456'])).not.toThrow();
+  });
+
+  it('throws on a mismatched checksum', () => {
+    expect(() => verifyChecksum('zzz', ['abc123', 'def456'])).toThrow(
+      'Mismatched checksum: expected one of abc123, def456, but got zzz',
+    );
+  });
+});
+
+describe('downloadCLI', () => {
+  let zipPath;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    zipPath = path.join(os.tmpdir(), `installer-test-${Date.now()}.zip`);
+    fs.writeFileSync(zipPath, 'tflint zip contents'); // eslint-disable-line security/detect-non-literal-fs-filename
+  });
+
+  afterEach(() => {
+    fs.rmSync(zipPath, { force: true });
+  });
+
+  it('skips verification when the checksum list is empty', async () => {
+    tc.downloadTool.mockResolvedValue(zipPath);
+    tc.extractZip.mockResolvedValue('/tmp/tflint');
+
+    const pathToCLI = await downloadCLI('https://example.com/tflint.zip', [], 'v0.50.0');
+
+    expect(pathToCLI).toBe('/tmp/tflint');
+    expect(tc.extractZip).toHaveBeenCalledWith(zipPath);
+  });
+
+  it('throws on a checksum mismatch', async () => {
+    tc.downloadTool.mockResolvedValue(zipPath);
+    tc.extractZip.mockResolvedValue('/tmp/tflint');
+
+    await expect(
+      downloadCLI('https://example.com/tflint.zip', ['not-the-real-checksum'], 'v0.50.0'),
+    ).rejects.toThrow(/Mismatched checksum: expected one of not-the-real-checksum, but got/);
+
+    expect(tc.extractZip).not.toHaveBeenCalled();
+  });
+});

--- a/src/release-target.js
+++ b/src/release-target.js
@@ -1,0 +1,68 @@
+/**
+ * Normalize version for tool-cache compatibility
+ * @param {string} version - Version string (e.g., "v0.50.0" or "0.50.0")
+ * @returns {string} - Normalized version without "v" prefix
+ */
+export function normalizeVersion(version) {
+  return version.replace(/^v/, '');
+}
+
+/**
+ * Get the GitHub platform architecture name
+ * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch
+ * @returns {string}
+ */
+export function mapArch(arch) {
+  const mappings = {
+    x32: '386',
+    x64: 'amd64',
+  };
+  return mappings[arch] || arch;
+}
+
+/**
+ * Get the GitHub OS name
+ * @param {string} osPlatform - https://nodejs.org/api/os.html#os_os_platform
+ * @returns {string}
+ */
+export function mapOS(osPlatform) {
+  const mappings = {
+    win32: 'windows',
+  };
+  return mappings[osPlatform] || osPlatform;
+}
+
+/**
+ * Build the release asset download URL for a tflint version
+ * @param {string} version - Release version (with any leading "v")
+ * @param {string} platform - GitHub OS name
+ * @param {string} arch - GitHub architecture name
+ * @returns {string}
+ */
+function buildDownloadUrl(version, platform, arch) {
+  return `https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${platform}_${arch}.zip`;
+}
+
+/**
+ * Resolve the release version and construct the download target
+ * @param {object} options
+ * @param {string} options.inputVersion - Requested version input ("latest", empty, or explicit)
+ * @param {string} options.platform - GitHub OS name
+ * @param {string} options.arch - GitHub architecture name
+ * @param {Function} options.fetchLatestReleaseName - Injected async fetcher returning the latest release name
+ * @returns {Promise<{version: string, downloadUrl: string}>}
+ */
+export async function resolveReleaseTarget({
+  inputVersion,
+  platform,
+  arch,
+  fetchLatestReleaseName,
+}) {
+  const version =
+    !inputVersion || inputVersion === 'latest' ? await fetchLatestReleaseName() : inputVersion;
+
+  return {
+    version,
+    downloadUrl: buildDownloadUrl(version, platform, arch),
+  };
+}

--- a/src/release-target.test.js
+++ b/src/release-target.test.js
@@ -1,0 +1,93 @@
+import { jest } from '@jest/globals';
+
+import { mapArch, mapOS, normalizeVersion, resolveReleaseTarget } from './release-target.js';
+
+describe('mapArch', () => {
+  it('maps x32 to 386', () => {
+    expect(mapArch('x32')).toBe('386');
+  });
+
+  it('maps x64 to amd64', () => {
+    expect(mapArch('x64')).toBe('amd64');
+  });
+
+  it('passes through unknown architectures', () => {
+    expect(mapArch('arm64')).toBe('arm64');
+  });
+});
+
+describe('mapOS', () => {
+  it('maps win32 to windows', () => {
+    expect(mapOS('win32')).toBe('windows');
+  });
+
+  it('passes through unknown platforms', () => {
+    expect(mapOS('linux')).toBe('linux');
+    expect(mapOS('darwin')).toBe('darwin');
+  });
+});
+
+describe('normalizeVersion', () => {
+  it('strips a leading v', () => {
+    expect(normalizeVersion('v0.50.0')).toBe('0.50.0');
+  });
+
+  it('leaves versions without a leading v unchanged', () => {
+    expect(normalizeVersion('0.50.0')).toBe('0.50.0');
+  });
+});
+
+describe('resolveReleaseTarget', () => {
+  it('uses an explicit version without calling the fetcher', async () => {
+    const fetchLatestReleaseName = jest.fn();
+
+    const result = await resolveReleaseTarget({
+      inputVersion: 'v0.50.0',
+      platform: 'linux',
+      arch: 'amd64',
+      fetchLatestReleaseName,
+    });
+
+    expect(fetchLatestReleaseName).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      version: 'v0.50.0',
+      downloadUrl:
+        'https://github.com/terraform-linters/tflint/releases/download/v0.50.0/tflint_linux_amd64.zip',
+    });
+  });
+
+  it('calls the fetcher when the input is "latest"', async () => {
+    const fetchLatestReleaseName = jest.fn().mockResolvedValue('v0.51.0');
+
+    const result = await resolveReleaseTarget({
+      inputVersion: 'latest',
+      platform: 'windows',
+      arch: '386',
+      fetchLatestReleaseName,
+    });
+
+    expect(fetchLatestReleaseName).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      version: 'v0.51.0',
+      downloadUrl:
+        'https://github.com/terraform-linters/tflint/releases/download/v0.51.0/tflint_windows_386.zip',
+    });
+  });
+
+  it('calls the fetcher when the input is empty', async () => {
+    const fetchLatestReleaseName = jest.fn().mockResolvedValue('v0.52.0');
+
+    const result = await resolveReleaseTarget({
+      inputVersion: '',
+      platform: 'darwin',
+      arch: 'arm64',
+      fetchLatestReleaseName,
+    });
+
+    expect(fetchLatestReleaseName).toHaveBeenCalledTimes(1);
+    expect(result.version).toBe('v0.52.0');
+    expect(result.downloadUrl).toBe(
+      'https://github.com/terraform-linters/tflint/releases/download/v0.52.0/tflint_darwin_arm64.zip',
+    );
+  });
+});

--- a/src/setup-tflint.js
+++ b/src/setup-tflint.js
@@ -1,8 +1,5 @@
-import crypto from 'crypto';
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { pipeline } from 'stream/promises';
 
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
@@ -11,40 +8,8 @@ import * as tc from '@actions/tool-cache';
 import { Octokit } from '@octokit/rest';
 
 import restoreCache from './cache-restore.js';
-
-/**
- * Normalize version for tool-cache compatibility
- * @param {string} version - Version string (e.g., "v0.50.0" or "0.50.0")
- * @returns {string} - Normalized version without "v" prefix
- */
-function normalizeVersion(version) {
-  return version.replace(/^v/, '');
-}
-
-/**
- * Get the GitHub platform architecture name
- * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch
- * @returns {string}
- */
-function mapArch(arch) {
-  const mappings = {
-    x32: '386',
-    x64: 'amd64',
-  };
-  return mappings[arch] || arch;
-}
-
-/**
- * Get the GitHub OS name
- * @param {string} osPlatform - https://nodejs.org/api/os.html#os_os_platform
- * @returns {string}
- */
-function mapOS(osPlatform) {
-  const mappings = {
-    win32: 'windows',
-  };
-  return mappings[osPlatform] || osPlatform;
-}
+import { downloadCLI } from './installer.js';
+import { mapArch, mapOS, normalizeVersion, resolveReleaseTarget } from './release-target.js';
 
 function getOctokit() {
   return new Octokit({
@@ -52,56 +17,14 @@ function getOctokit() {
   });
 }
 
-async function getTFLintVersion(inputVersion) {
-  if (!inputVersion || inputVersion === 'latest') {
-    const octokit = getOctokit();
-    const response = await octokit.repos.getLatestRelease({
-      owner: 'terraform-linters',
-      repo: 'tflint',
-    });
-    core.debug(`... version resolved to [${response.data.name}]`);
-    return response.data.name;
-  }
-
-  return inputVersion;
-}
-
-async function fileSHA256(filePath) {
-  const hash = crypto.createHash('sha256');
-  const fileStream = fs.createReadStream(filePath); // eslint-disable-line security/detect-non-literal-fs-filename
-
-  await pipeline(fileStream, hash);
-  return hash.digest('hex');
-}
-
-async function downloadCLI(url, checksums, version) {
-  core.info(`Attempting to download ${version}...`);
-  core.info(`Acquiring ${version} from ${url}`);
-  const pathToCLIZip = await tc.downloadTool(url);
-
-  if (checksums.length > 0) {
-    core.debug('Verifying checksum of downloaded file');
-
-    const checksum = await fileSHA256(pathToCLIZip);
-
-    if (!checksums.includes(checksum)) {
-      throw new Error(
-        `Mismatched checksum: expected one of ${checksums.join(', ')}, but got ${checksum}`,
-      );
-    }
-
-    core.debug('SHA256 hash verified successfully');
-  }
-
-  core.info('Extracting...');
-  const pathToCLI = await tc.extractZip(pathToCLIZip);
-  core.debug(`tflint CLI path is ${pathToCLI}.`);
-
-  if (!pathToCLIZip || !pathToCLI) {
-    throw new Error(`Unable to download tflint from ${url}`);
-  }
-
-  return pathToCLI;
+async function fetchLatestReleaseName() {
+  const octokit = getOctokit();
+  const response = await octokit.repos.getLatestRelease({
+    owner: 'terraform-linters',
+    repo: 'tflint',
+  });
+  core.debug(`... version resolved to [${response.data.name}]`);
+  return response.data.name;
 }
 
 async function getInstalledVersion() {
@@ -154,9 +77,14 @@ async function run() {
     const inputVersion = core.getInput('tflint_version');
     const checksums = core.getMultilineInput('checksums');
     const wrapper = core.getInput('tflint_wrapper') === 'true';
-    const version = await getTFLintVersion(inputVersion);
     const platform = mapOS(os.platform());
     const arch = mapArch(os.arch());
+    const { version, downloadUrl } = await resolveReleaseTarget({
+      inputVersion,
+      platform,
+      arch,
+      fetchLatestReleaseName,
+    });
     const normalizedVersion = normalizeVersion(version);
 
     // Check if tool is already cached
@@ -165,9 +93,8 @@ async function run() {
       core.info(`Found TFLint ${version} in cache @ ${pathToCLI}`);
     } else {
       core.debug(`Getting download URL for tflint version ${version}: ${platform} ${arch}`);
-      const url = `https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${platform}_${arch}.zip`;
 
-      pathToCLI = await downloadCLI(url, checksums, version);
+      pathToCLI = await downloadCLI(downloadUrl, checksums, version);
 
       core.info('Adding to the tool cache...');
       pathToCLI = await tc.cacheDir(pathToCLI, 'tflint', normalizedVersion, arch);


### PR DESCRIPTION
Deepens the tflint acquisition path in `src/setup-tflint.js`, which had grown into one `run()` that mixed input parsing, platform mapping, the GitHub Releases API, download, checksum verification, zip extraction, the tool cache, and `core.*` side effects. The pure helpers (`mapArch`, `mapOS`, `normalizeVersion`) were unexported, so nothing tested them.

Extracts two modules behind narrow interfaces:

- `src/release-target.js` resolves the version and builds the download target. It takes an injected `fetchLatestReleaseName`, so the Octokit call stays out of the pure logic and the URL and version mapping are testable without the network.
- `src/installer.js` owns download, checksum verification, and extraction (`downloadCLI`, `fileSHA256`, and an extracted `verifyChecksum`).

`run()` becomes wiring. `installWrapper`, `getInstalledVersion`, and matcher registration stay in `src/setup-tflint.js` because they depend on `__dirname`, which jest's ESM loader does not provide.

Behavior is unchanged: the download URL still uses `version` (with any leading `v`) while the tool cache keys on `normalizedVersion` (without it), checksum verification is still skipped when no checksums are supplied, and every `core.*` message and output is preserved.

## Testing

Adds `src/release-target.test.js` and `src/installer.test.js`, taking the suite from 1 test to 16. They cover the arch and OS mappings, version resolution (an explicit version skips the fetcher; `latest` or empty calls it), URL construction, and checksum gating (empty skips, mismatch throws).
