### PR TITLE
Name the wrapper hand-off protocol in a shared module

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -49621,6 +49621,16 @@ const dist_src_Octokit = Octokit.plugin(requestLog, legacyRestEndpointMethods, p
 );
 
 
+;// CONCATENATED MODULE: ./wrapper/lib/tflint-protocol.js
+
+
+const BIN_SUFFIX = 'tflint-bin';
+const CLI_PATH_ENV = 'TFLINT_CLI_PATH';
+
+function resolveBinPath(dir) {
+  return [dir, BIN_SUFFIX].join(path.sep);
+}
+
 ;// CONCATENATED MODULE: ./node_modules/@actions/cache/node_modules/@actions/glob/lib/internal-glob-options-helper.js
 
 /**
@@ -100116,6 +100126,8 @@ async function resolveReleaseTarget({
 
 
 
+
+
 function getOctokit() {
   return new dist_src_Octokit({
     auth: getInput('github_token'),
@@ -100158,7 +100170,7 @@ async function getInstalledVersion() {
 
 async function installWrapper(pathToCLI) {
   // Move the original tflint binary to a new location
-  await mv(external_path_.join(pathToCLI, 'tflint'), external_path_.join(pathToCLI, 'tflint-bin'));
+  await mv(external_path_.join(pathToCLI, 'tflint'), external_path_.join(pathToCLI, BIN_SUFFIX));
 
   // Copy the wrapper script to the tflint binary location
   await io_cp(
@@ -100172,7 +100184,7 @@ async function installWrapper(pathToCLI) {
     external_path_.join(pathToCLI, 'package.json'),
   );
 
-  exportVariable('TFLINT_CLI_PATH', pathToCLI);
+  exportVariable(CLI_PATH_ENV, pathToCLI);
 }
 
 async function run() {

--- a/dist/index1.js
+++ b/dist/index1.js
@@ -30915,12 +30915,20 @@ class OutputListener {
 
 /* harmony default export */ const output_listener = (OutputListener);
 
+;// CONCATENATED MODULE: ./wrapper/lib/tflint-protocol.js
+
+
+const BIN_SUFFIX = 'tflint-bin';
+const CLI_PATH_ENV = 'TFLINT_CLI_PATH';
+
+function resolveBinPath(dir) {
+  return [dir, BIN_SUFFIX].join(external_path_namespaceObject.sep);
+}
+
 ;// CONCATENATED MODULE: ./wrapper/lib/tflint-bin.js
 
 
-const pathToCLI = [process.env.TFLINT_CLI_PATH, `tflint-bin`].join(external_path_namespaceObject.sep);
-
-/* harmony default export */ const tflint_bin = (pathToCLI);
+/* harmony default export */ const tflint_bin = (resolveBinPath(process.env[CLI_PATH_ENV]));
 
 ;// CONCATENATED MODULE: ./wrapper/tflint.js
 

--- a/src/setup-tflint.js
+++ b/src/setup-tflint.js
@@ -7,6 +7,8 @@ import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
 import { Octokit } from '@octokit/rest';
 
+import { BIN_SUFFIX, CLI_PATH_ENV } from '../wrapper/lib/tflint-protocol.js';
+
 import restoreCache from './cache-restore.js';
 import { downloadCLI } from './installer.js';
 import { mapArch, mapOS, normalizeVersion, resolveReleaseTarget } from './release-target.js';
@@ -53,7 +55,7 @@ async function getInstalledVersion() {
 
 async function installWrapper(pathToCLI) {
   // Move the original tflint binary to a new location
-  await io.mv(path.join(pathToCLI, 'tflint'), path.join(pathToCLI, 'tflint-bin'));
+  await io.mv(path.join(pathToCLI, 'tflint'), path.join(pathToCLI, BIN_SUFFIX));
 
   // Copy the wrapper script to the tflint binary location
   await io.cp(
@@ -67,7 +69,7 @@ async function installWrapper(pathToCLI) {
     path.join(pathToCLI, 'package.json'),
   );
 
-  core.exportVariable('TFLINT_CLI_PATH', pathToCLI);
+  core.exportVariable(CLI_PATH_ENV, pathToCLI);
 }
 
 async function run() {

--- a/wrapper/lib/tflint-bin.js
+++ b/wrapper/lib/tflint-bin.js
@@ -1,5 +1,3 @@
-import path from 'path';
+import { CLI_PATH_ENV, resolveBinPath } from './tflint-protocol.js';
 
-const pathToCLI = [process.env.TFLINT_CLI_PATH, `tflint-bin`].join(path.sep);
-
-export default pathToCLI;
+export default resolveBinPath(process.env[CLI_PATH_ENV]);

--- a/wrapper/lib/tflint-protocol.js
+++ b/wrapper/lib/tflint-protocol.js
@@ -1,0 +1,8 @@
+import path from 'path';
+
+export const BIN_SUFFIX = 'tflint-bin';
+export const CLI_PATH_ENV = 'TFLINT_CLI_PATH';
+
+export function resolveBinPath(dir) {
+  return [dir, BIN_SUFFIX].join(path.sep);
+}

--- a/wrapper/test/tflint-protocol.test.js
+++ b/wrapper/test/tflint-protocol.test.js
@@ -1,0 +1,14 @@
+import path from 'path';
+
+import { BIN_SUFFIX, CLI_PATH_ENV, resolveBinPath } from '../lib/tflint-protocol';
+
+describe('tflint-protocol', () => {
+  it('exposes the protocol constants', () => {
+    expect(BIN_SUFFIX).toBe('tflint-bin');
+    expect(CLI_PATH_ENV).toBe('TFLINT_CLI_PATH');
+  });
+
+  it('resolves the binary path under a directory', () => {
+    expect(resolveBinPath('/some/dir')).toBe(`/some/dir${path.sep}tflint-bin`);
+  });
+});


### PR DESCRIPTION
Names the wrapper hand-off protocol that was duplicated across two separately-built bundles. When `tflint_wrapper` is enabled, `installWrapper` renames the real binary to `tflint-bin`, drops the wrapper in as `tflint`, and exports `TFLINT_CLI_PATH`; at runtime `wrapper/lib/tflint-bin.js` rebuilds the path as `${TFLINT_CLI_PATH}/tflint-bin`. The suffix, the env var, and the path layout were bare string literals on both sides, so changing one silently broke the other.

Adds `wrapper/lib/tflint-protocol.js` exporting `BIN_SUFFIX`, `CLI_PATH_ENV`, and `resolveBinPath(dir)`. Both `installWrapper` and `wrapper/lib/tflint-bin.js` import from it. `wrapper/tflint.js` is unchanged, and `tflint-bin.js` keeps its default-export shape.

Behavior is identical: same rename target, env var, and resolved path.

## Testing

Adds `wrapper/test/tflint-protocol.test.js` verifying the constants and that `resolveBinPath` joins `dir` and the suffix with `path.sep`.