### PR TITLE
Add tflint_version_file input to read the TFLint version from a file

### DIFF
--- a/.github/workflows/fixtures/.tool-versions
+++ b/.github/workflows/fixtures/.tool-versions
@@ -1,0 +1,2 @@
+terraform 1.9.0
+tflint 0.52.0

--- a/.github/workflows/fixtures/.tool-versions
+++ b/.github/workflows/fixtures/.tool-versions
@@ -1,2 +1,0 @@
-terraform 1.9.0
-tflint 0.52.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,27 @@ jobs:
           checksums: bb0a3a6043ea1bcd221fc95d49bac831bb511eb31946ca6a4050983e9e584578
       - run: tflint -v
 
+  integration-version-file:
+    runs-on: ubuntu-latest
+    name: 'Integration test: version file'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Use Action
+        id: setup-tflint
+        uses: ./
+        with:
+          tflint_version_file: .github/workflows/fixtures/.tool-versions
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate
+        run: tflint -v | grep 0.52.0
+      - name: Verify version output
+        run: |
+          if [[ "${{ steps.setup-tflint.outputs.tflint-version }}" != "0.52.0" ]]; then
+            echo "Expected version output '0.52.0', got '${{ steps.setup-tflint.outputs.tflint-version }}'"
+            exit 1
+          fi
+
   integration-matchers:
     name: 'Integration test: matchers (tflint_version: ${{ matrix.tflint_version }})'
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,11 +143,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Write version file
+        run: |
+          cat > .tool-versions <<'EOF'
+          terraform 1.9.0
+          tflint 0.52.0
+          EOF
       - name: Use Action
         id: setup-tflint
         uses: ./
         with:
-          tflint_version_file: .github/workflows/fixtures/.tool-versions
+          tflint_version_file: .tool-versions
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate
         run: tflint -v | grep 0.52.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ If version is `"latest"`, the action will get the latest version number using [O
 
 Default: `"latest"`
 
+### `tflint_version_file`
+
+Path to a file containing the TFLint version to install, so the version can live alongside your other tooling pins instead of being hardcoded in the workflow.
+
+Two formats are supported:
+
+- An [asdf](https://asdf-vm.com/) / [mise](https://mise.jdx.dev/) `.tool-versions` file — the version is read from its `tflint <version>` line (other tools in the file are ignored).
+- A plain version file whose entire contents are a single version (e.g. `0.52.0` or `v0.52.0`).
+
+The version may be written with or without a leading `v`.
+
+This input is used only when `tflint_version` is unset or `latest`. If `tflint_version` is set to an explicit version, it takes precedence and `tflint_version_file` is ignored.
+
+```yaml
+- uses: terraform-linters/setup-tflint@v6
+  with:
+    tflint_version_file: .tool-versions
+```
+
 ### `checksums`
 
 A newline-delimited list of valid checksums (SHA256 hashes) for the downloaded TFLint binary. When set, the action will verify that the binary matches one of these checksums before proceeding.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: TFLint version to install
     required: false
     default: latest
+  tflint_version_file:
+    description: Path to a file containing the TFLint version to install (an asdf/mise `.tool-versions` entry, or a plain version file). Used when `tflint_version` is unset or `latest`.
+    required: false
   github_token:
     description: GitHub token - used when getting the latest version of tflint
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -100053,6 +100053,41 @@ function normalizeVersion(version) {
 }
 
 /**
+ * Ensure a version string is a release tag. TFLint release tags are "v"-prefixed,
+ * so a bare version (e.g. an asdf-style "0.50.0") is coerced to "v0.50.0".
+ * @param {string} version - Version string (e.g., "0.50.0" or "v0.50.0")
+ * @returns {string} - Version with a leading "v"
+ */
+function ensureVersionTag(version) {
+  return /^\d/.test(version) ? `v${version}` : version;
+}
+
+/**
+ * Parse a TFLint version from a version file's contents.
+ *
+ * Supports the asdf/mise `.tool-versions` format (a `tflint <version>` line,
+ * possibly alongside other tools) and a plain version file whose entire
+ * contents are a single version token.
+ * @param {string} contents - Raw version file contents
+ * @returns {string|null} - The parsed version, or null when none is found
+ */
+function parseVersionFile(contents) {
+  // asdf/mise `.tool-versions`: a `tflint <version>` entry.
+  const toolVersionsMatch = contents.match(/^\s*tflint\s+v?(\S+)/m);
+  if (toolVersionsMatch) {
+    return toolVersionsMatch[1];
+  }
+
+  // Plain version file: a single bare version token (optionally "v"-prefixed).
+  const trimmed = contents.trim();
+  if (/^v?\d\S*$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+/**
  * Get the GitHub platform architecture name
  * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch
  * @returns {string}
@@ -100103,8 +100138,9 @@ async function resolveReleaseTarget({
   arch,
   fetchLatestReleaseName,
 }) {
-  const version =
+  const resolved =
     !inputVersion || inputVersion === 'latest' ? await fetchLatestReleaseName() : inputVersion;
+  const version = ensureVersionTag(resolved);
 
   return {
     version,
@@ -100113,6 +100149,7 @@ async function resolveReleaseTarget({
 }
 
 ;// CONCATENATED MODULE: ./src/setup-tflint.js
+
 
 
 
@@ -100168,6 +100205,46 @@ async function getInstalledVersion() {
   }
 }
 
+/**
+ * Resolve the requested TFLint version, preferring an explicit `tflint_version`
+ * and falling back to a version read from `tflint_version_file` when provided.
+ * @returns {string} - The requested version ("latest", empty, or explicit/file)
+ */
+function resolveRequestedVersion() {
+  const inputVersion = getInput('tflint_version');
+  const versionFile = getInput('tflint_version_file');
+
+  if (!versionFile) {
+    return inputVersion;
+  }
+
+  // An explicit version wins over the file; warn so the file is not silently ignored.
+  if (inputVersion && inputVersion !== 'latest') {
+    warning(
+      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
+    );
+
+    return inputVersion;
+  }
+
+  // The path comes from a trusted workflow input, not from untrusted runtime data.
+  const filePath = external_path_.resolve(versionFile);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  if (!external_fs_namespaceObject.existsSync(filePath)) {
+    throw new Error(`tflint_version_file not found: ${versionFile}`);
+  }
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const fileVersion = parseVersionFile(external_fs_namespaceObject.readFileSync(filePath, 'utf8'));
+  if (!fileVersion) {
+    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
+  }
+
+  info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
+
+  return fileVersion;
+}
+
 async function installWrapper(pathToCLI) {
   // Move the original tflint binary to a new location
   await mv(external_path_.join(pathToCLI, 'tflint'), external_path_.join(pathToCLI, BIN_SUFFIX));
@@ -100191,7 +100268,7 @@ async function run() {
   try {
     await cache_restore();
 
-    const inputVersion = getInput('tflint_version');
+    const inputVersion = resolveRequestedVersion();
     const checksums = getMultilineInput('checksums');
     const wrapper = getInput('tflint_wrapper') === 'true';
     const platform = mapOS(external_os_.platform());

--- a/dist/index.js
+++ b/dist/index.js
@@ -100087,6 +100087,62 @@ function parseVersionFile(contents) {
   return null;
 }
 
+// Default logging sink for resolveRequestedVersion when none is injected.
+function release_target_noop() {
+  // Intentionally does nothing; used when no logger is injected.
+}
+
+/**
+ * Resolve the requested TFLint version from the action inputs, preferring an
+ * explicit `tflint_version` and falling back to a version read from
+ * `tflint_version_file` when one is provided.
+ *
+ * Parsing and the input-precedence rules are kept here (rather than in the
+ * action entrypoint) so they can be unit tested without the Actions runtime.
+ * @param {object} options
+ * @param {string} options.inputVersion - The `tflint_version` input ("latest", empty, or explicit)
+ * @param {string} options.versionFile - The `tflint_version_file` input (a path, or empty)
+ * @param {(path: string) => boolean} options.fileExists - Returns true when the version file exists
+ * @param {(path: string) => string} options.readFile - Reads the version file's contents
+ * @param {(message: string) => void} [options.warn] - Sink for warnings (defaults to no-op)
+ * @param {(message: string) => void} [options.info] - Sink for info messages (defaults to no-op)
+ * @returns {string} - The requested version ("latest", empty, or explicit/file)
+ */
+function resolveRequestedVersion({
+  inputVersion,
+  versionFile,
+  fileExists,
+  readFile,
+  warn = release_target_noop,
+  info = release_target_noop,
+}) {
+  if (!versionFile) {
+    return inputVersion;
+  }
+
+  // An explicit version wins over the file; warn so the file is not silently ignored.
+  if (inputVersion && inputVersion !== 'latest') {
+    warn(
+      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
+    );
+
+    return inputVersion;
+  }
+
+  if (!fileExists(versionFile)) {
+    throw new Error(`tflint_version_file not found: ${versionFile}`);
+  }
+
+  const fileVersion = parseVersionFile(readFile(versionFile));
+  if (!fileVersion) {
+    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
+  }
+
+  info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
+
+  return fileVersion;
+}
+
 /**
  * Get the GitHub platform architecture name
  * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch
@@ -100206,43 +100262,24 @@ async function getInstalledVersion() {
 }
 
 /**
- * Resolve the requested TFLint version, preferring an explicit `tflint_version`
- * and falling back to a version read from `tflint_version_file` when provided.
+ * Read the requested TFLint version from the action inputs. The version-file
+ * parsing and input-precedence rules live in `resolveRequestedVersion`
+ * (release-target.js) so they can be unit tested; this wrapper only supplies
+ * the Actions-runtime concerns (inputs, path resolution, filesystem, logging).
  * @returns {string} - The requested version ("latest", empty, or explicit/file)
  */
-function resolveRequestedVersion() {
-  const inputVersion = getInput('tflint_version');
-  const versionFile = getInput('tflint_version_file');
-
-  if (!versionFile) {
-    return inputVersion;
-  }
-
-  // An explicit version wins over the file; warn so the file is not silently ignored.
-  if (inputVersion && inputVersion !== 'latest') {
-    warning(
-      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
-    );
-
-    return inputVersion;
-  }
-
-  // The path comes from a trusted workflow input, not from untrusted runtime data.
-  const filePath = external_path_.resolve(versionFile);
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  if (!external_fs_namespaceObject.existsSync(filePath)) {
-    throw new Error(`tflint_version_file not found: ${versionFile}`);
-  }
-
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  const fileVersion = parseVersionFile(external_fs_namespaceObject.readFileSync(filePath, 'utf8'));
-  if (!fileVersion) {
-    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
-  }
-
-  info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
-
-  return fileVersion;
+function getRequestedVersion() {
+  return resolveRequestedVersion({
+    inputVersion: getInput('tflint_version'),
+    versionFile: getInput('tflint_version_file'),
+    // The path comes from a trusted workflow input, not from untrusted runtime data.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fileExists: (file) => external_fs_namespaceObject.existsSync(external_path_.resolve(file)),
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    readFile: (file) => external_fs_namespaceObject.readFileSync(external_path_.resolve(file), 'utf8'),
+    warn: warning,
+    info: info,
+  });
 }
 
 async function installWrapper(pathToCLI) {
@@ -100268,7 +100305,7 @@ async function run() {
   try {
     await cache_restore();
 
-    const inputVersion = resolveRequestedVersion();
+    const inputVersion = getRequestedVersion();
     const checksums = getMultilineInput('checksums');
     const wrapper = getInput('tflint_wrapper') === 'true';
     const platform = mapOS(external_os_.platform());

--- a/src/release-target.js
+++ b/src/release-target.js
@@ -8,6 +8,41 @@ export function normalizeVersion(version) {
 }
 
 /**
+ * Ensure a version string is a release tag. TFLint release tags are "v"-prefixed,
+ * so a bare version (e.g. an asdf-style "0.50.0") is coerced to "v0.50.0".
+ * @param {string} version - Version string (e.g., "0.50.0" or "v0.50.0")
+ * @returns {string} - Version with a leading "v"
+ */
+export function ensureVersionTag(version) {
+  return /^\d/.test(version) ? `v${version}` : version;
+}
+
+/**
+ * Parse a TFLint version from a version file's contents.
+ *
+ * Supports the asdf/mise `.tool-versions` format (a `tflint <version>` line,
+ * possibly alongside other tools) and a plain version file whose entire
+ * contents are a single version token.
+ * @param {string} contents - Raw version file contents
+ * @returns {string|null} - The parsed version, or null when none is found
+ */
+export function parseVersionFile(contents) {
+  // asdf/mise `.tool-versions`: a `tflint <version>` entry.
+  const toolVersionsMatch = contents.match(/^\s*tflint\s+v?(\S+)/m);
+  if (toolVersionsMatch) {
+    return toolVersionsMatch[1];
+  }
+
+  // Plain version file: a single bare version token (optionally "v"-prefixed).
+  const trimmed = contents.trim();
+  if (/^v?\d\S*$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+/**
  * Get the GitHub platform architecture name
  * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch
  * @returns {string}
@@ -58,8 +93,9 @@ export async function resolveReleaseTarget({
   arch,
   fetchLatestReleaseName,
 }) {
-  const version =
+  const resolved =
     !inputVersion || inputVersion === 'latest' ? await fetchLatestReleaseName() : inputVersion;
+  const version = ensureVersionTag(resolved);
 
   return {
     version,

--- a/src/release-target.js
+++ b/src/release-target.js
@@ -42,6 +42,62 @@ export function parseVersionFile(contents) {
   return null;
 }
 
+// Default logging sink for resolveRequestedVersion when none is injected.
+function noop() {
+  // Intentionally does nothing; used when no logger is injected.
+}
+
+/**
+ * Resolve the requested TFLint version from the action inputs, preferring an
+ * explicit `tflint_version` and falling back to a version read from
+ * `tflint_version_file` when one is provided.
+ *
+ * Parsing and the input-precedence rules are kept here (rather than in the
+ * action entrypoint) so they can be unit tested without the Actions runtime.
+ * @param {object} options
+ * @param {string} options.inputVersion - The `tflint_version` input ("latest", empty, or explicit)
+ * @param {string} options.versionFile - The `tflint_version_file` input (a path, or empty)
+ * @param {(path: string) => boolean} options.fileExists - Returns true when the version file exists
+ * @param {(path: string) => string} options.readFile - Reads the version file's contents
+ * @param {(message: string) => void} [options.warn] - Sink for warnings (defaults to no-op)
+ * @param {(message: string) => void} [options.info] - Sink for info messages (defaults to no-op)
+ * @returns {string} - The requested version ("latest", empty, or explicit/file)
+ */
+export function resolveRequestedVersion({
+  inputVersion,
+  versionFile,
+  fileExists,
+  readFile,
+  warn = noop,
+  info = noop,
+}) {
+  if (!versionFile) {
+    return inputVersion;
+  }
+
+  // An explicit version wins over the file; warn so the file is not silently ignored.
+  if (inputVersion && inputVersion !== 'latest') {
+    warn(
+      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
+    );
+
+    return inputVersion;
+  }
+
+  if (!fileExists(versionFile)) {
+    throw new Error(`tflint_version_file not found: ${versionFile}`);
+  }
+
+  const fileVersion = parseVersionFile(readFile(versionFile));
+  if (!fileVersion) {
+    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
+  }
+
+  info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
+
+  return fileVersion;
+}
+
 /**
  * Get the GitHub platform architecture name
  * @param {string} arch - https://nodejs.org/api/os.html#os_os_arch

--- a/src/release-target.test.js
+++ b/src/release-target.test.js
@@ -1,6 +1,13 @@
 import { jest } from '@jest/globals';
 
-import { mapArch, mapOS, normalizeVersion, resolveReleaseTarget } from './release-target.js';
+import {
+  ensureVersionTag,
+  mapArch,
+  mapOS,
+  normalizeVersion,
+  parseVersionFile,
+  resolveReleaseTarget,
+} from './release-target.js';
 
 describe('mapArch', () => {
   it('maps x32 to 386', () => {
@@ -34,6 +41,50 @@ describe('normalizeVersion', () => {
 
   it('leaves versions without a leading v unchanged', () => {
     expect(normalizeVersion('0.50.0')).toBe('0.50.0');
+  });
+});
+
+describe('ensureVersionTag', () => {
+  it('prepends a "v" to a bare version', () => {
+    expect(ensureVersionTag('0.50.0')).toBe('v0.50.0');
+  });
+
+  it('leaves an already "v"-prefixed version unchanged', () => {
+    expect(ensureVersionTag('v0.50.0')).toBe('v0.50.0');
+  });
+
+  it('leaves "latest" unchanged', () => {
+    expect(ensureVersionTag('latest')).toBe('latest');
+  });
+});
+
+describe('parseVersionFile', () => {
+  it('reads a bare version from a .tool-versions tflint entry', () => {
+    expect(parseVersionFile('tflint 0.50.0\n')).toBe('0.50.0');
+  });
+
+  it('strips a leading "v" from a .tool-versions tflint entry', () => {
+    expect(parseVersionFile('tflint v0.50.0\n')).toBe('0.50.0');
+  });
+
+  it('finds the tflint entry among other tools', () => {
+    expect(parseVersionFile('terraform 1.9.0\ntflint 0.51.0\nfoo 1.2.3\n')).toBe('0.51.0');
+  });
+
+  it('reads a plain version file', () => {
+    expect(parseVersionFile('0.52.0\n')).toBe('0.52.0');
+  });
+
+  it('reads a plain version file with a "v" prefix', () => {
+    expect(parseVersionFile('v0.52.0\n')).toBe('v0.52.0');
+  });
+
+  it('returns null for empty contents', () => {
+    expect(parseVersionFile('\n  \n')).toBeNull();
+  });
+
+  it('returns null when no tflint entry is present', () => {
+    expect(parseVersionFile('terraform 1.9.0\n')).toBeNull();
   });
 });
 
@@ -88,6 +139,23 @@ describe('resolveReleaseTarget', () => {
     expect(result.version).toBe('v0.52.0');
     expect(result.downloadUrl).toBe(
       'https://github.com/terraform-linters/tflint/releases/download/v0.52.0/tflint_darwin_arm64.zip',
+    );
+  });
+
+  it('normalizes a bare explicit version to a "v"-prefixed tag', async () => {
+    const fetchLatestReleaseName = jest.fn();
+
+    const result = await resolveReleaseTarget({
+      inputVersion: '0.50.0',
+      platform: 'linux',
+      arch: 'amd64',
+      fetchLatestReleaseName,
+    });
+
+    expect(fetchLatestReleaseName).not.toHaveBeenCalled();
+    expect(result.version).toBe('v0.50.0');
+    expect(result.downloadUrl).toBe(
+      'https://github.com/terraform-linters/tflint/releases/download/v0.50.0/tflint_linux_amd64.zip',
     );
   });
 });

--- a/src/release-target.test.js
+++ b/src/release-target.test.js
@@ -7,6 +7,7 @@ import {
   normalizeVersion,
   parseVersionFile,
   resolveReleaseTarget,
+  resolveRequestedVersion,
 } from './release-target.js';
 
 describe('mapArch', () => {
@@ -71,6 +72,10 @@ describe('parseVersionFile', () => {
     expect(parseVersionFile('terraform 1.9.0\ntflint 0.51.0\nfoo 1.2.3\n')).toBe('0.51.0');
   });
 
+  it('ignores leading whitespace before the tflint entry', () => {
+    expect(parseVersionFile('  tflint 0.53.0\n')).toBe('0.53.0');
+  });
+
   it('reads a plain version file', () => {
     expect(parseVersionFile('0.52.0\n')).toBe('0.52.0');
   });
@@ -79,12 +84,141 @@ describe('parseVersionFile', () => {
     expect(parseVersionFile('v0.52.0\n')).toBe('v0.52.0');
   });
 
+  it('trims surrounding whitespace from a plain version file', () => {
+    expect(parseVersionFile('  \n  0.52.0  \n  \n')).toBe('0.52.0');
+  });
+
+  it('reads a plain version file without a trailing newline', () => {
+    expect(parseVersionFile('0.52.0')).toBe('0.52.0');
+  });
+
+  it('prefers the tflint entry over a leading plain-looking line', () => {
+    expect(parseVersionFile('0.40.0\ntflint 0.52.0\n')).toBe('0.52.0');
+  });
+
   it('returns null for empty contents', () => {
+    expect(parseVersionFile('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only contents', () => {
     expect(parseVersionFile('\n  \n')).toBeNull();
   });
 
   it('returns null when no tflint entry is present', () => {
     expect(parseVersionFile('terraform 1.9.0\n')).toBeNull();
+  });
+
+  it('returns null for a comment-only / non-version plain file', () => {
+    expect(parseVersionFile('# pin tflint here\n')).toBeNull();
+  });
+});
+
+describe('resolveRequestedVersion', () => {
+  const makeReader = (contents) => ({
+    fileExists: jest.fn().mockReturnValue(true),
+    readFile: jest.fn().mockReturnValue(contents),
+  });
+
+  it('returns the explicit version and never touches the filesystem when no file is set', () => {
+    const { fileExists, readFile } = makeReader('tflint 0.52.0\n');
+
+    const result = resolveRequestedVersion({
+      inputVersion: 'v0.50.0',
+      versionFile: '',
+      fileExists,
+      readFile,
+    });
+
+    expect(result).toBe('v0.50.0');
+    expect(fileExists).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('passes through an empty version input when no file is set', () => {
+    const { fileExists, readFile } = makeReader('tflint 0.52.0\n');
+
+    expect(
+      resolveRequestedVersion({ inputVersion: '', versionFile: '', fileExists, readFile }),
+    ).toBe('');
+  });
+
+  it('reads the version from the file when no explicit version is given', () => {
+    const { fileExists, readFile } = makeReader('terraform 1.9.0\ntflint 0.52.0\n');
+    const info = jest.fn();
+
+    const result = resolveRequestedVersion({
+      inputVersion: '',
+      versionFile: '.tool-versions',
+      fileExists,
+      readFile,
+      info,
+    });
+
+    expect(result).toBe('0.52.0');
+    expect(readFile).toHaveBeenCalledWith('.tool-versions');
+    expect(info).toHaveBeenCalledWith('Resolved TFLint version 0.52.0 from .tool-versions');
+  });
+
+  it('reads the version from the file when the explicit version is "latest"', () => {
+    const { fileExists, readFile } = makeReader('0.52.0\n');
+
+    const result = resolveRequestedVersion({
+      inputVersion: 'latest',
+      versionFile: '.tflint-version',
+      fileExists,
+      readFile,
+    });
+
+    expect(result).toBe('0.52.0');
+  });
+
+  it('lets an explicit version win over the file and warns', () => {
+    const { fileExists, readFile } = makeReader('tflint 0.52.0\n');
+    const warn = jest.fn();
+
+    const result = resolveRequestedVersion({
+      inputVersion: 'v0.50.0',
+      versionFile: '.tool-versions',
+      fileExists,
+      readFile,
+      warn,
+    });
+
+    expect(result).toBe('v0.50.0');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
+    );
+    expect(fileExists).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the version file does not exist', () => {
+    const fileExists = jest.fn().mockReturnValue(false);
+    const readFile = jest.fn();
+
+    expect(() =>
+      resolveRequestedVersion({
+        inputVersion: '',
+        versionFile: 'missing.tool-versions',
+        fileExists,
+        readFile,
+      }),
+    ).toThrow('tflint_version_file not found: missing.tool-versions');
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the version file cannot be parsed', () => {
+    const { fileExists, readFile } = makeReader('terraform 1.9.0\n');
+
+    expect(() =>
+      resolveRequestedVersion({
+        inputVersion: '',
+        versionFile: '.tool-versions',
+        fileExists,
+        readFile,
+      }),
+    ).toThrow('Could not parse a TFLint version from tflint_version_file: .tool-versions');
   });
 });
 

--- a/src/setup-tflint.js
+++ b/src/setup-tflint.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -11,7 +12,13 @@ import { BIN_SUFFIX, CLI_PATH_ENV } from '../wrapper/lib/tflint-protocol.js';
 
 import restoreCache from './cache-restore.js';
 import { downloadCLI } from './installer.js';
-import { mapArch, mapOS, normalizeVersion, resolveReleaseTarget } from './release-target.js';
+import {
+  mapArch,
+  mapOS,
+  normalizeVersion,
+  parseVersionFile,
+  resolveReleaseTarget,
+} from './release-target.js';
 
 function getOctokit() {
   return new Octokit({
@@ -53,6 +60,46 @@ async function getInstalledVersion() {
   }
 }
 
+/**
+ * Resolve the requested TFLint version, preferring an explicit `tflint_version`
+ * and falling back to a version read from `tflint_version_file` when provided.
+ * @returns {string} - The requested version ("latest", empty, or explicit/file)
+ */
+function resolveRequestedVersion() {
+  const inputVersion = core.getInput('tflint_version');
+  const versionFile = core.getInput('tflint_version_file');
+
+  if (!versionFile) {
+    return inputVersion;
+  }
+
+  // An explicit version wins over the file; warn so the file is not silently ignored.
+  if (inputVersion && inputVersion !== 'latest') {
+    core.warning(
+      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
+    );
+
+    return inputVersion;
+  }
+
+  // The path comes from a trusted workflow input, not from untrusted runtime data.
+  const filePath = path.resolve(versionFile);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`tflint_version_file not found: ${versionFile}`);
+  }
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const fileVersion = parseVersionFile(fs.readFileSync(filePath, 'utf8'));
+  if (!fileVersion) {
+    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
+  }
+
+  core.info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
+
+  return fileVersion;
+}
+
 async function installWrapper(pathToCLI) {
   // Move the original tflint binary to a new location
   await io.mv(path.join(pathToCLI, 'tflint'), path.join(pathToCLI, BIN_SUFFIX));
@@ -76,7 +123,7 @@ async function run() {
   try {
     await restoreCache();
 
-    const inputVersion = core.getInput('tflint_version');
+    const inputVersion = resolveRequestedVersion();
     const checksums = core.getMultilineInput('checksums');
     const wrapper = core.getInput('tflint_wrapper') === 'true';
     const platform = mapOS(os.platform());

--- a/src/setup-tflint.js
+++ b/src/setup-tflint.js
@@ -16,8 +16,8 @@ import {
   mapArch,
   mapOS,
   normalizeVersion,
-  parseVersionFile,
   resolveReleaseTarget,
+  resolveRequestedVersion,
 } from './release-target.js';
 
 function getOctokit() {
@@ -61,43 +61,24 @@ async function getInstalledVersion() {
 }
 
 /**
- * Resolve the requested TFLint version, preferring an explicit `tflint_version`
- * and falling back to a version read from `tflint_version_file` when provided.
+ * Read the requested TFLint version from the action inputs. The version-file
+ * parsing and input-precedence rules live in `resolveRequestedVersion`
+ * (release-target.js) so they can be unit tested; this wrapper only supplies
+ * the Actions-runtime concerns (inputs, path resolution, filesystem, logging).
  * @returns {string} - The requested version ("latest", empty, or explicit/file)
  */
-function resolveRequestedVersion() {
-  const inputVersion = core.getInput('tflint_version');
-  const versionFile = core.getInput('tflint_version_file');
-
-  if (!versionFile) {
-    return inputVersion;
-  }
-
-  // An explicit version wins over the file; warn so the file is not silently ignored.
-  if (inputVersion && inputVersion !== 'latest') {
-    core.warning(
-      'Both tflint_version and tflint_version_file are set; using tflint_version and ignoring tflint_version_file.',
-    );
-
-    return inputVersion;
-  }
-
-  // The path comes from a trusted workflow input, not from untrusted runtime data.
-  const filePath = path.resolve(versionFile);
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`tflint_version_file not found: ${versionFile}`);
-  }
-
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  const fileVersion = parseVersionFile(fs.readFileSync(filePath, 'utf8'));
-  if (!fileVersion) {
-    throw new Error(`Could not parse a TFLint version from tflint_version_file: ${versionFile}`);
-  }
-
-  core.info(`Resolved TFLint version ${fileVersion} from ${versionFile}`);
-
-  return fileVersion;
+function getRequestedVersion() {
+  return resolveRequestedVersion({
+    inputVersion: core.getInput('tflint_version'),
+    versionFile: core.getInput('tflint_version_file'),
+    // The path comes from a trusted workflow input, not from untrusted runtime data.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fileExists: (file) => fs.existsSync(path.resolve(file)),
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    readFile: (file) => fs.readFileSync(path.resolve(file), 'utf8'),
+    warn: core.warning,
+    info: core.info,
+  });
 }
 
 async function installWrapper(pathToCLI) {
@@ -123,7 +104,7 @@ async function run() {
   try {
     await restoreCache();
 
-    const inputVersion = resolveRequestedVersion();
+    const inputVersion = getRequestedVersion();
     const checksums = core.getMultilineInput('checksums');
     const wrapper = core.getInput('tflint_wrapper') === 'true';
     const platform = mapOS(os.platform());


### PR DESCRIPTION
Adds a `tflint_version_file` input so the TFLint version can be pinned in a file alongside your other tooling pins, instead of being hardcoded in the workflow.

Supported formats:
- An asdf/mise `.tool-versions` file — read from its `tflint <version>` line (other tools in the file are ignored).
- A plain version file whose contents are a single version (`0.52.0` or `v0.52.0`).

Bare (asdf-style) versions without a leading `v` are accepted and coerced to the release-tag form. `tflint_version_file` is consulted only when `tflint_version` is unset or `latest`; an explicit `tflint_version` takes precedence.

Validation:
- `npm test` — 34 passing (added unit tests for `parseVersionFile`, `ensureVersionTag`, and bare-version resolution)
- `npm run lint` — clean
- `npm run build && git diff --exit-code` — dist rebuilt, no drift
- New `integration-version-file` CI job exercises `.tool-versions` end-to-end